### PR TITLE
Add did:3 processing, resolution processing, and some clarification on the rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In this transformation, the legacy did document is called `legacyDidDocument`.
 1. Copy the unqualified DID string into a new property `unqualified_did`.
 2. Create an initial string value `did:peer:2`.
 3. Create an empty **ordered list** called `authenticationFingerprints`.
-4. Loop through the `authentication` list from the `legacyDidDocument` and for each of the entries perform the following steps:
+4. Loop through the `authentication` and `publicKey` lists from the `legacyDidDocument` and for each of the entries perform the following steps:
    1. if the value of the `type` property in the entry is `Ed25519SignatureAuthentication2018` and the entry contains a `publicKey`
       1. resolve the `publicKey` property from the `publicKey` list in the `legacyDidDocument` to a value named `resolvedLegacyAuthentication`.
       2. If the referenced public key could not be found in the `publicKey`, an error must be thrown and the process must be aborted, otherwise continnue the processing of the entry.
@@ -17,23 +17,22 @@ In this transformation, the legacy did document is called `legacyDidDocument`.
    3. else ignore the entry and continue with the next entry.
    4. Continue the processing of the entry by calculating the multibase, multicodec encoded public key from the value of `publicKeyBase58` property in `resolvedLegacyAuthentication` and assign this to the the property `fingerprint`.
    5. Add the `fingerprint` value to the `authenticationFingerprints` list.
-5. Loop through the `publicKey` list from the `legacyDidDocument` and for each of the entries perform the following steps:
-   1. if the value of the `type` property is not `Ed25519Signature2018` ignore the entry and continue with the next entry.
-   2. Calculate the multibase, multicodec encoded public key from the value of `publicKeyBase58` property in the entry and assign this to the the property `fingerprint`.
-   3. If the value of `fingerprint` already exists in the list `authenticationFingerprints` ignore the entry and continue with the next entry.
-   4. Add the `fingerprint` value to the `authenticationFingerprints` list.
-6. For each entry in the `authenticationFingerprints` list perform the following steps:
+5. For each entry in the `authenticationFingerprints` list perform the following steps:
    1. Append `.V` and the `fingerprint` to the `did:peer:2` string.
-7. Loop through the `service` list from the `legacyDidDocument` and for each of the entries perform the following steps:
-   1. if the value of the `type` property is not `IndyAgent` ignore the entry and continue with the next entry.
-   2. Create a new object called `service` and assign it the following properties (in alphabetical order). If your language does not support ordered objects, you can use
+6. Loop through the `service` list from the `legacyDidDocument` and for each of the entries perform the following steps:
+   1. If the value of the `type` property is not `IndyAgent`, `did-communication` or `DIDCommMessaging` ignore the entry and continue with the next entry.
+   2. Create a JSON structure with the following properties.
       1. `priority` based on the `priority` property from the entry.
       2. `r` based no the `routingKeys` property from the entry.
       3. `recipientKeys` based on the `recipientKeys` property from the entry.
       4. `s` based on the `serviceEndpoint` property from the entry.
-      5. `t` based on the `type` property from the entry.
-   3. Follow `did:peer:2` service encoding algorithm from the [DID Peer Spec](https://identity.foundation/peer-did-method-spec/index.html#generation-method) and append the final value to the `did:peer:2` string.
-8. From the resulting string that is the `did:peer:2` DID, generate the `did:peer:3` as defined in the [DID Peer Spec](), and populate the `did` property of the DID with the `did:peer:3` string.
+      5. `t` to the value `dm`
+   3. Encode the JSON as outlined in `did:peer:2` service encoding algorithm from the [DID Peer Spec](https://identity.foundation/peer-did-method-spec/index.html#generation-method):
+      1. Convert the JSON to a string, and remove unnecessary whitespace, such as spaces and newlines.
+      2. Base64URL encode the string (padding MUST be removed as the "=" character is, per the DID Core Specification, not permitted in a DID)
+      3. Prefix encoded service with a period character (`.`) and `S`.
+   4. Append the resulting encoded string to the `did:peer:2` string.
+7. From the resulting string that is the `did:peer:2` DID, generate the `did:peer:3` as defined in the [DID Peer Spec](), and populate the `did` property of the DID with the `did:peer:3` string.
 
 ## Resolving
 

--- a/README.md
+++ b/README.md
@@ -6,24 +6,25 @@ This repository describes how to transform legacy dids and did documents to qual
 
 In this transformation, the legacy did document is called `legacyDidDocument`.
 
-1. Create a new property called `did` and assign it the initial string value `did:peer:2`.
-2. Create an empty **ordered list** called `authenticationFingerprints`.
-3. Loop through the `authentication` list from the `legacyDidDocument` and for each of the entries perform the following steps:
+1. Copy the unqualified DID string into a new property `unqualified_did`.
+2. Create an initial string value `did:peer:2`.
+3. Create an empty **ordered list** called `authenticationFingerprints`.
+4. Loop through the `authentication` list from the `legacyDidDocument` and for each of the entries perform the following steps:
    1. if the value of the `type` property in the entry is `Ed25519SignatureAuthentication2018` and the entry contains a `publicKey`
       1. resolve the `publicKey` property from the `publicKey` list in the `legacyDidDocument` to a value named `resolvedLegacyAuthentication`.
-      2. If the referenced public key could not be found in the `publicKey`, an error must be thrown and the process must be aborted, otherwise continue with step 2.4
-   2. else if the value of the `type` property is `Ed25519Signature2018`, assign the value of the entry to `resolvedLegacyAuthentication` and continue with step 2.4
+      2. If the referenced public key could not be found in the `publicKey`, an error must be thrown and the process must be aborted, otherwise continnue the processing of the entry.
+   2. else if the value of the `type` property is `Ed25519Signature2018`, assign the value of the entry to `resolvedLegacyAuthentication` and continue the processing of the entry.
    3. else ignore the entry and continue with the next entry.
-   4. Calculate the multibase, multicodec encoded public key from the value of `publicKeyBase58` property in `resolvedLegacyAuthentication` and assign this to the the property `fingerprint`.
+   4. Continue the processing of the entry by calculating the multibase, multicodec encoded public key from the value of `publicKeyBase58` property in `resolvedLegacyAuthentication` and assign this to the the property `fingerprint`.
    5. Add the `fingerprint` value to the `authenticationFingerprints` list.
-4. Loop through the `publicKey` list from the `legacyDidDocument` and for each of the entries perform the following steps:
+5. Loop through the `publicKey` list from the `legacyDidDocument` and for each of the entries perform the following steps:
    1. if the value of the `type` property is not `Ed25519Signature2018` ignore the entry and continue with the next entry.
    2. Calculate the multibase, multicodec encoded public key from the value of `publicKeyBase58` property in the entry and assign this to the the property `fingerprint`.
    3. If the value of `fingerprint` already exists in the list `authenticationFingerprints` ignore the entry and continue with the next entry.
    4. Add the `fingerprint` value to the `authenticationFingerprints` list.
-5. For each entry in the `authenticationFingerprints` list perform the following steps:
-   1. Append `.V` and the `fingerprint` to the `did` property.
-6. Loop through the `service` list from the `legacyDidDocument` and for each of the entries perform the following steps:
+6. For each entry in the `authenticationFingerprints` list perform the following steps:
+   1. Append `.V` and the `fingerprint` to the `did:peer:2` string.
+7. Loop through the `service` list from the `legacyDidDocument` and for each of the entries perform the following steps:
    1. if the value of the `type` property is not `IndyAgent` ignore the entry and continue with the next entry.
    2. Create a new object called `service` and assign it the following properties (in alphabetical order). If your language does not support ordered objects, you can use
       1. `priority` based on the `priority` property from the entry.
@@ -31,7 +32,16 @@ In this transformation, the legacy did document is called `legacyDidDocument`.
       3. `recipientKeys` based on the `recipientKeys` property from the entry.
       4. `s` based on the `serviceEndpoint` property from the entry.
       5. `t` based on the `type` property from the entry.
-   3. Follow `did:peer:2` service encoding algorithm from the spec and append the final value to the `did` property.
+   3. Follow `did:peer:2` service encoding algorithm from the [DID Peer Spec](https://identity.foundation/peer-did-method-spec/index.html#generation-method) and append the final value to the `did:peer:2` string.
+8. From the resulting string that is the `did:peer:2` DID, generate the `did:peer:3` as defined in the [DID Peer Spec](), and populate the `did` property of the DID with the `did:peer:3` string.
+
+## Resolving
+
+A reference to the DID may be received as the unqualified DID, `did:peer:2` or `did:peer:3`, with all needing to be resolved to the same DID record.
+
+* If the unqualified DID is to be resolved, lookup the unqualified DID using the `unqualified_did` property and return the DID record.
+* If a `did:peer:2` is received, transform the DID into a `did:peer:3`, lookup the DID using the `did` property and return the DID record.
+* If a `did:peer:3` is received, lookup the DID using the `did` property and return the DID record.
 
 ## Test Vectors
 


### PR DESCRIPTION
Given that we want to support `did:peer:3` as soon as the DID has been transmitted from the creating to the receiving agent, and by definition, all these DIDs have been transmitted, I think we should target `did:peer:3` DIDs, with `did:peer:2`s as intermediaries.  This addresses #2.

I tried to clarify a bit the wording around the if/else processing.  It's messy regardless, but hopefully it's not worse :-).  A diagram might be helpful, or overkill.

I added a resolution section on what to do on receipt of a DID to be found, whether it is an unqualified DID (expected as we transition from unqualified to qualified DIDs), a `did:peer:2` (not really expected), or a `did:peer:3`.

There was discussion on the Aries Working Group call to move this content to an Appendix in this Community Coordinated Update.  @TimoGlastra -- would you be open to that?  Link to the [Community Coordinated Update PR](https://github.com/hyperledger/aries-rfcs/pull/793).
